### PR TITLE
mejorar -> weekly-updates/weekly-update.2015-05-08.md

### DIFF
--- a/weekly-updates/weekly-update.2015-05-08.md
+++ b/weekly-updates/weekly-update.2015-05-08.md
@@ -6,7 +6,7 @@ Esta semana publicamos dos versiones de io.js, la [v2.0.0](https://iojs.org/dist
 #### 2.0.1
 * **async_wrap**: (Trevor Norris) [#1614](https://github.com/iojs/io.js/pull/1614)
   - ahora es posible filtrar por proveedores
-  - pequeños flags han sido removidos y reemplazados con llamadas a métodos en el objeto vinculante
+  - pequeños flags han sido removidos y reemplazados con llamadas a bindings
   - _ten en cuenta que esta es una API inestable, y las adiciones de fetaures y cambios profundos no cambiarán la versión de semver_
 * **libuv**: resuelve numerosos issues de io.js:
   - [#862](https://github.com/iojs/io.js/issues/862) previene la creación de procesos hijos con descriptores de stdio inválidos


### PR DESCRIPTION
Referente a los últimos comentarios de @vrunoa en #7 para mejorar el artículo
cc @iojs-es/revision @iojs-es/evangelizacion 

Dejo aquí las notas que @vrunoa ha escrito en #7. 

> Consulta, en vez de; "el listado de cambios completo está disponible" no debería ser "el listado completo de cambios está disponible" ? 
> [https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637L2](https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637L2)
## 

> "bit flags have been removed and replaced with method calls on the binding object", para este caso creo q "bit flags" esta utilizando "bit" como binario, y no como pequeño.
> 
> `las banderas binarias han sido removidas y reemplazadas con llamadas a métodos en el objeto vinculante` en vez de `pequeños flags han sido removidos y reemplazados con llamadas a métodos en el objeto vinculante`
> que opinan ? 
> 
> "flags" se estaba traduciendo ?
> 
> [https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637L9](https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637L9)
## 

> Para "_ten en cuenta que esta es una API inestable, y las adiciones de fetaures y cambios profundos no cambiarán la versión de semver_", me parece que faltaría el conector en la oración, el `so`
> 
> "ten en cuenta que esta API es inestable, por lo que los agregados de features y cambios profundos no cambiarían la version semver de iosjs"
> 
> Les parece ?
> [https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637L10](https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637L10)
## 

> "should properly fix Windows termination errors", esta " debe finalizar apropiadamente errores"
> y me parece que sería, 
> "debería arreglar los errores de terminación en Windows"
> [https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637L15](https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637L15)
## 

> Detallecito:
>  **smalloc**: el módulo 'smalloc' ha sido deprecado debido a los cambios que se vienen en V8 4.4 que la volverán inusable.
> 
> debería ser "... lo volverán inusable", ya que habla de el módulo. 
> [https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637R33](https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637R33)
## 

> En este caso;
> "add Promise, Map and Set inspection support", no sería "se agrega soporte de inspeccion para Promise, Map y Set" ? 
> 
> [https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637R34](https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637R34)
## 

> **breaking change** se tradujo en un punto anterior como **cambio profundo**, por lo que me parece que también debería traducirse en este caso, y mantener la consistencia. Les parece ? 
> [https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637R54](https://github.com/iojs-es/evangelism/pull/7/files#diff-990055bd127a0937331cfbe36a1ad637R54)
